### PR TITLE
Throw exception on malformed hash (Fixes #12)

### DIFF
--- a/src/clojure/buddy/hashers.clj
+++ b/src/clojure/buddy/hashers.clj
@@ -271,7 +271,7 @@
   (let [[alg salt cc mc pll password] (str/split encryptedpassword #"\$")
         alg (keyword alg)]
     (if (some nil? [salt cc mc pll password])
-      (throw (Exception. "Malformed hash")))
+      (throw (ex-info "Malformed hash" {})))
     {:alg alg
      :salt (codecs/hex->bytes salt)
      :password (codecs/hex->bytes password)
@@ -284,7 +284,7 @@
   (let [[alg salt iterations password] (str/split encryptedpassword #"\$")
         alg (keyword alg)]
     (if (some nil? [salt iterations password])
-      (throw (Exception. "Malformed hash")))
+      (throw (ex-info "Malformed hash" {})))
     {:alg alg
      :salt (codecs/hex->bytes salt)
      :password (codecs/hex->bytes password)

--- a/src/clojure/buddy/hashers.clj
+++ b/src/clojure/buddy/hashers.clj
@@ -270,6 +270,8 @@
   [encryptedpassword]
   (let [[alg salt cc mc pll password] (str/split encryptedpassword #"\$")
         alg (keyword alg)]
+    (if (some nil? [salt cc mc pll password])
+      (throw (Exception. "Malformed hash")))
     {:alg alg
      :salt (codecs/hex->bytes salt)
      :password (codecs/hex->bytes password)
@@ -281,6 +283,8 @@
   [encryptedpassword]
   (let [[alg salt iterations password] (str/split encryptedpassword #"\$")
         alg (keyword alg)]
+    (if (some nil? [salt iterations password])
+      (throw (Exception. "Malformed hash")))
     {:alg alg
      :salt (codecs/hex->bytes salt)
      :password (codecs/hex->bytes password)


### PR DESCRIPTION
The issue in #12 occurred in parse-password, while splitting the hash by $, all symbols besides alg were nil. This will throw an expcetion if any of the symbols are nil. I can change the exception type or message if needed.