### PR TITLE
[buddy/hashers] Fix reflection warnings.

### DIFF
--- a/src/clojure/buddy/hashers.clj
+++ b/src/clojure/buddy/hashers.clj
@@ -20,11 +20,13 @@
             [buddy.core.bytes :as bytes]
             [clojure.string :as str]
             [clojurewerkz.scrypt.core :as scrypt])
-  (:import org.bouncycastle.crypto.digests.SHA1Digest
+  (:import org.bouncycastle.crypto.Digest
+           org.bouncycastle.crypto.digests.SHA1Digest
            org.bouncycastle.crypto.digests.SHA256Digest
            org.bouncycastle.crypto.digests.SHA3Digest
            org.bouncycastle.crypto.generators.PKCS5S2ParametersGenerator
            org.bouncycastle.crypto.generators.BCrypt
+           org.bouncycastle.crypto.params.KeyParameter
            java.security.Security))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
@@ -87,11 +89,12 @@
   (let [salt (codecs/to-bytes (or salt (nonce/random-bytes 12)))
         alg (keyword (str "pbkdf2+" (name digest)))
         iterations (or iterations (get +iterations+ alg))
-        digest (hash/resolve-digest-engine digest)
+        ^Digest digest (hash/resolve-digest-engine digest)
         dsize (* 8 (.getDigestSize digest))
         pgen (doto (PKCS5S2ParametersGenerator. digest)
                (.init password salt iterations))
-        password (.getKey (.generateDerivedParameters pgen dsize))]
+        ^KeyParameter cparams (.generateDerivedParameters pgen dsize)
+        password (.getKey cparams)]
     {:alg alg
      :password password
      :salt salt
@@ -126,7 +129,8 @@
         iterations (or iterations (get +iterations+ alg))
         pgen (doto (PKCS5S2ParametersGenerator. (SHA3Digest. 256))
                (.init password salt iterations))
-        password (.getKey (.generateDerivedParameters pgen 256))]
+        ^KeyParameter cparams (.generateDerivedParameters pgen 256)
+        password (.getKey cparams)]
     {:alg alg
      :password password
      :salt salt
@@ -216,7 +220,8 @@
         iterations (or iterations (get +iterations+ alg))
         pgen (doto (PKCS5S2ParametersGenerator. (SHA256Digest.))
                (.init password salt iterations))
-        password (.getKey (.generateDerivedParameters pgen 160))]
+        ^KeyParameter cparams (.generateDerivedParameters pgen 160)
+        password (.getKey cparams)]
     {:alg alg
      :password password
      :salt salt


### PR DESCRIPTION
Thanks for this excellent library, we use it to hash many many strings, and it works great.

Similar to this `buddy-core` pull request: https://github.com/funcool/buddy-core/pull/53
 - but for this `buddy-hashers` repo

Fixes https://github.com/funcool/buddy-hashers/issues/20