### PR TITLE
Add Argon2id support (Fixes #13)

### DIFF
--- a/doc/user-guide.md
+++ b/doc/user-guide.md
@@ -17,6 +17,7 @@ Supported password hashers algorithms:
 | `:bcrypt+sha384`   | Yes | BCrypt password hasher combined with sha384 |
 | `:pbkdf2+sha1`     | Yes | Password-Based Key Derivation Function 2 (as defined in RFC2898) |
 | `:scrypt`          | Yes | Password-Based Key Derivation Function created by Colin Percival |
+| `:argon2id`        | Yes | Memory-Hard Key Derivation Function for password hashing and other applications |
 
 
 ## Install
@@ -93,6 +94,7 @@ Table that deails available options and their defaults:
 | `:scrypt` | `:salt`, `:cpucost`, `:memcost`, `:parallelism` | salt=(random 12 bytes), cpucost=65536, memcost=8, parallelism=1 |
 | `:bcrypt+sha512` | `:salt`, `:iterations` | iterations=12, salt=(random 12 bytes) |
 | `:pbkdf2+sha256` | `:salt`, `:iterations` | iterations=100000, salt=(random 12 bytes) |
+| `:argon2id` | `:salt`, `:memory`, `:iterations`, `:parallelism` | salt=(random 16 bytes), memory=65536, iterations=2, parallelism=1 |
 
 
 ### Limiting algorithms

--- a/src/clj/buddy/hashers.clj
+++ b/src/clj/buddy/hashers.clj
@@ -25,6 +25,9 @@
            org.bouncycastle.crypto.digests.SHA3Digest
            org.bouncycastle.crypto.generators.PKCS5S2ParametersGenerator
            org.bouncycastle.crypto.generators.BCrypt
+           org.bouncycastle.crypto.generators.Argon2BytesGenerator
+           org.bouncycastle.crypto.params.Argon2Parameters
+           org.bouncycastle.crypto.params.Argon2Parameters$Builder
            java.security.Security))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
@@ -42,7 +45,9 @@
    :bcrypt+sha384 12
    :bcrypt+blake2b-512 12
    :scrypt {:cpucost 65536
-            :memcost 8}})
+            :memcost 8}
+   :argon2id {:memory 65536
+              :iterations 2}})
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Impl Interface
@@ -166,6 +171,29 @@
      :password password
      :salt salt}))
 
+(defmethod derive-password :argon2id
+  [{:keys [alg password salt memory iterations parallelism] :as pwdparams}]
+  (let [salt (codecs/to-bytes (or salt (nonce/random-bytes 16)))
+        memory (or memory (get-in +iterations+ [:argon2id :memory])) ;; KiB
+        iterations (or iterations (get-in +iterations+ [:argon2id :iterations]))
+        parallelism (or parallelism 1)
+        params (-> (Argon2Parameters$Builder. Argon2Parameters/ARGON2_id)
+                   (.withSalt salt)
+                   (.withMemoryAsKB memory)
+                   (.withIterations iterations)
+                   (.withParallelism parallelism)
+                   (.build))
+        generator (Argon2BytesGenerator.)
+        hash (byte-array 32)]
+    (.init generator params)
+    (.generateBytes generator ^bytes password hash)
+    {:alg alg
+     :memory memory
+     :iterations iterations
+     :parallelism parallelism
+     :password hash
+     :salt salt}))
+
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Key Verification
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
@@ -237,6 +265,12 @@
         password (codecs/bytes->hex password)]
     (format "scrypt$%s$%s$%s$%s$%s" salt cpucost memcost parallelism password)))
 
+(defmethod format-password :argon2id
+  [{:keys [password salt memory iterations parallelism]}]
+  (let [salt (codecs/bytes->hex salt)
+        password (codecs/bytes->hex password)]
+    (format "argon2id$%s$%s$%s$%s$%s" salt memory iterations parallelism password)))
+
 (defmethod format-password :default
   [{:keys [alg password salt iterations]}]
   (let [algname (name alg)
@@ -261,6 +295,19 @@
      :password (codecs/hex->bytes password)
      :cpucost (Integer/parseInt cc)
      :memcost (Integer/parseInt mc)
+     :parallelism (Integer/parseInt pll)}))
+
+(defmethod parse-password :argon2id
+  [encryptedpassword]
+  (let [[alg salt mem iters pll password] (str/split encryptedpassword #"\$")
+        alg (keyword alg)]
+    (if (some nil? [salt mem iters pll password])
+      (throw (ex-info "Malformed hash" {})))
+    {:alg alg
+     :salt (codecs/hex->bytes salt)
+     :password (codecs/hex->bytes password)
+     :memory (Integer/parseInt mem)
+     :iterations (Integer/parseInt iters)
      :parallelism (Integer/parseInt pll)}))
 
 (defmethod parse-password :default
@@ -303,6 +350,15 @@
          desired-memcost
          (or (> desired-memcost memcost)
              (> desired-cpucost cpucost)))))
+
+(defmethod must-update? :argon2id
+  [{:keys [alg memory iterations]}]
+  (let [desired-memory (get-in +iterations+ [:argon2id :memory])
+        desired-iterations (get-in +iterations+ [:argon2id :iterations])]
+    (and desired-memory
+         desired-iterations
+         (or (> desired-memory memory)
+             (> desired-iterations iterations)))))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Public Api

--- a/test/buddy/hashers_tests.clj
+++ b/test/buddy/hashers_tests.clj
@@ -32,7 +32,8 @@
       :bcrypt+sha512
       :bcrypt+sha384
       :bcrypt+blake2b-512
-      :scrypt)))
+      :scrypt
+      :argon2id)))
 
 (deftest buddy-hashers-verify
   (let [pwd "my-test-password"]
@@ -46,7 +47,8 @@
       :bcrypt+sha512
       :bcrypt+sha384
       :bcrypt+blake2b-512
-      :scrypt)))
+      :scrypt
+      :argon2id)))
 
 (deftest confirm-check-failure
   (let [pwd-good "my-test-password"
@@ -62,7 +64,8 @@
       :bcrypt+sha512
       :bcrypt+sha384
       :bcrypt+blake2b-512
-      :scrypt)))
+      :scrypt
+      :argon2id)))
 
 (deftest confirm-verify-failure
   (let [pwd-good "my-test-password"
@@ -78,7 +81,8 @@
       :bcrypt+sha512
       :bcrypt+sha384
       :bcrypt+blake2b-512
-      :scrypt)))
+      :scrypt
+      :argon2id)))
 
 (deftest buddy-hashers-nil
   (let [pwd "my-test-password"
@@ -100,7 +104,8 @@
       :bcrypt+sha512
       :bcrypt+sha384
       :bcrypt+blake2b-512
-      :scrypt)))
+      :scrypt
+      :argon2id)))
 
 ;; Confirm that the algorithm used is always embedded at the
 ;; start of the hash, and that the salt is also appended (after
@@ -120,7 +125,8 @@
       :bcrypt+sha512
       :bcrypt+sha384
       :bcrypt+blake2b-512
-      :scrypt)))
+      :scrypt
+      :argon2id)))
 
 (deftest limit-available-algorithms-check
   (let [pwd   (hashers/encrypt "hello" {:alg :scrypt})
@@ -184,7 +190,8 @@
         bcrypt+blake2b-512 "bcrypt+blake2b-512$95d0488b2b69c79d4f48ab39338c322e$12$40a4ef31b6dd390b27bd6fc3c2fdeabfb1db85c9bef25c22"
         bcrypt+sha512-legacy "bcrypt+sha512$680bf9ad0bf9f8249bfebb85$12$243261243132244b4e2e4e456650704558323964686e6c64644f4b73656a6879584f635a4f6b7778596132475036772e6c2e784f49596631556f7679"
         bcrypt+sha512 "bcrypt+sha512$b932bf208c7f3ecb563eebe89c39115b$12$bc3633d1f07c47edd91f0e7cf5649b040ea868cec63cda31"
-        bcrypt+sha384 "bcrypt+sha384$5c3b8cc880e0dd91520a900a8c8c6223$12$fa6e0a810b81b04634b19311e77eb00ba1d0f12c570adafa"]
+        bcrypt+sha384 "bcrypt+sha384$5c3b8cc880e0dd91520a900a8c8c6223$12$fa6e0a810b81b04634b19311e77eb00ba1d0f12c570adafa"
+        argon2id "argon2id$9682763587dcaf962161d4b24d7246b3$65536$2$1$4181787747eb7330abda8f42b2fb0dfab207e5cf0c0031a2233a00484d739c8c"]
     (is (hashers/check "test" pbkdf2+sha1))
     (is (hashers/check "test" pbkdf2+sha256))
     (is (hashers/check "test" pbkdf2+sha256-legacy))
@@ -196,6 +203,7 @@
     (is (hashers/check "test" bcrypt+sha512))
     (is (hashers/check "test" bcrypt+sha384))
     (is (hashers/check "test" bcrypt+blake2b-512))
+    (is (hashers/check "test" argon2id))
     ))
 
 (deftest debug-time-bench
@@ -213,5 +221,6 @@
       :bcrypt+sha512
       :bcrypt+sha384
       :bcrypt+blake2b-512
-      :scrypt)))
+      :scrypt
+      :argon2id)))
 


### PR DESCRIPTION
Hi,
I'm not sure if you're still considering having Argon2 support in buddy-hashers, but if so, please have a look at this. It uses Bouncy Castle implementation of Argon2id hashing function.